### PR TITLE
support for style.cssText (getting and setting)

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,10 +43,7 @@ function Style (el) {
 }
 
 Style.prototype.setProperty = function (n,v) {
-  var attr = this.el.getAttribute('style');
-
-  !attr && this.el.setAttribute('style', '');
-  this.el._setProperty(this.styles, {name: n, value:v});
+    this.el._setProperty(this.styles, {name: n, value:v});
 }
 
 Style.prototype.getProperty = function(n) {    
@@ -129,11 +126,19 @@ Element.prototype.appendChild = function(child) {
 }
 
 Element.prototype.setAttribute = function (n, v) {
+  if (n == 'style'){
+    this.style.cssText = v
+  } else {
     this._setProperty(this.attributes, Attribute, n, v);
+  }
 }
 
 Element.prototype.getAttribute = function(n) {
+  if (n == 'style'){
+    return this.style.cssText
+  } else {
     return this._getProperty(this.attributes, n);
+  }
 }
 
 Element.prototype.replaceChild = function(newChild, oldChild) {

--- a/test/index.js
+++ b/test/index.js
@@ -127,3 +127,15 @@ test('set/get style.cssText', function(t){
 
   t.end()
 })
+
+test('style set/getAttribute', function(t){
+  var div = document.createElement('div')
+
+  div.style.setProperty('background', 'green')
+  t.equal(div.getAttribute('style'), 'background:green;')
+
+  div.setAttribute('style', 'color: red; padding: 8px')
+  t.equal(div.getAttribute('style'), 'color:red;padding:8px;')
+
+  t.end()
+})


### PR DESCRIPTION
This allows you to set the style attribute as a css string rather than just by key. It parses the css string and sets the appropriate properties.

``` js
div.style.cssText = "border: 1px solid #333333; padding: 10px"
```

Relevant hyperscript PR: https://github.com/dominictarr/hyperscript/pull/10

See https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration

EDIT: just added support for getAttribute setAttribute of style as well. 
