### PR TITLE
use @raynos's class-list module

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ global.Comment  = Comment
 global.Text     = Text
 global.document = new Document()
 
+var ClassList = require('class-list')
+
 function Document() {}
 
 Document.prototype.createTextNode = function(v) {
@@ -72,16 +74,6 @@ Style.prototype.__defineSetter__('cssText', function (v) {
     }, this)
 })
 
-function classList(el) {  
-  this.el = el;
-}
-
-classList.prototype.add = function(cls) {    
-  !this.el.getAttribute('class') && this.el.setAttribute('class','');  
-  var v = this.el.getAttribute('class').value;
-  this.el.setAttribute('class',v.length ? v+cls+' ' : v+cls);
-}
-
 function Attribute(name, value){  
   if (name) {
     this.name = name;
@@ -94,7 +86,7 @@ function Element() {
     var self = this;
 
     this.style = new Style(this)
-    this.classList = new classList(this);
+    this.classList = ClassList(this);
     this.childNodes = [];
     this.attributes = [];
     this.dataset = {};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "class-list": "~0.1.1"
+  },
   "scripts": {
     "test": "tap test/*.js"
   },


### PR DESCRIPTION
this makes multiple classes work correctly with hyperscript.

The problem was that class is not really an attribute, it's a weird, different thing.
try setting `el.class = 'foo bar'` in the chrome console.
instead, you have to do `el.className = 'foo bar'`
