### PR TITLE
Render inline styles in outerHTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,7 +263,9 @@ Element.prototype.__defineGetter__('outerHTML', function () {
       }      
   }
 
-  a.push('<'+this.nodeName + _propertify() + _stringify(this.attributes) + _dataify(this.dataset) +'>')
+  var attrs = this.style.cssText ? this.attributes.concat([{name: 'style'}]) : this.attributes;
+
+  a.push('<'+this.nodeName + _propertify() + _stringify(attrs) + _dataify(this.dataset) +'>')
   
   if (!VOID_ELEMENTS[this.nodeName.toUpperCase()]){
     a.push(this.innerHTML)

--- a/test/index.js
+++ b/test/index.js
@@ -139,3 +139,15 @@ test('style set/getAttribute', function(t){
 
   t.end()
 })
+
+test('render outerHTML with inline style', function(t){
+  var div = document.createElement('div')
+
+  div.style.setProperty('background', 'green')
+  t.equal(div.outerHTML, '<div style="background:green;"></div>')
+
+  div.style.cssText = 'color: red; padding: 8px'
+  t.equal(div.outerHTML, '<div style="color:red;padding:8px;"></div>')
+
+  t.end()
+})


### PR DESCRIPTION
This addresses an issue where inline styles don't appear in the outerHTML of an Element (see test case). Appending `{name: 'style'}` to the array here seemed like the least obtrusive way to go, but you may have something more elegant in mind. Thanks for considering this PR!