### PR TITLE
more realistic handling of props vs attributes

### DIFF
--- a/attributes-elements.js
+++ b/attributes-elements.js
@@ -10,11 +10,15 @@ var HTML_ATTRIBUTES = {
     'input',
   ]),
 
-  'accept-charset': 'form',
+  'accept-charset': new Set([
+    'form',
+  ]),
 
   'accesskey': 'GLOBAL',
 
-  'action': 'form',
+  'action': new Set([
+    'form',
+  ]),
 
   'align': new Set([
     'applet',
@@ -40,14 +44,214 @@ var HTML_ATTRIBUTES = {
     'input',
   ]),
 
-  'async': 'script',
+  'async': new Set([
+    'script',
+  ]),
 
   'autocomplete': new Set([
     'form',
     'input',
   ]),
 
-  // TODO
+  'autofocus': new Set([
+    'button',
+    'input',
+    'keygen',
+    'select',
+    'textarea',
+  ]),
+
+  'autoplay': new Set([
+    'audio',
+    'video',
+  ]),
+
+  'autosave': new Set([
+    'input',
+  ]),
+
+  'bgcolor': new Set([
+    'body',
+    'col',
+    'colgroup',
+    'marquee',
+    'table',
+    'tbody',
+    'tfoot',
+    'td',
+    'th',
+    'tr',
+  ]),
+
+  'border': new Set([
+    'img',
+    'object',
+    'table',
+  ]),
+
+  'buffered': new Set([
+    'audio',
+    'video',
+  ]),
+
+  'challenge': new Set([
+    'keygen',
+  ]),
+
+  'charset': new Set([
+    'meta',
+    'script',
+  ]),
+
+  'checked': new Set([
+    'command',
+    'input',
+  ]),
+
+  'cite': new Set([
+    'blockquote',
+    'del',
+    'ins',
+    'q',
+  ]),
+
+  'class': 'GLOBAL',
+
+  'code': new Set([
+    'applet',
+  ]),
+
+  'codebase': new Set([
+    'applet',
+  ]),
+
+  'color': new Set([
+    'basefont',
+    'font',
+    'hr',
+  ]),
+
+  'cols': new Set([
+    'textarea',
+  ]),
+
+  'colspan': new Set([
+    'td',
+    'th',
+  ]),
+
+  'content': new Set([
+    'meta',
+  ]),
+
+  'contenteditable': 'GLOBAL',
+
+  'contextmenu': 'GLOBAL',
+
+  'controls': new Set([
+    'audio',
+    'video',
+  ]),
+
+  'coords': new Set([
+    'area',
+  ]),
+
+  'data': new Set([
+    'object',
+  ]),
+
+  'datetime': new Set([
+    'del',
+    'ins',
+    'time',
+  ]),
+
+  'default': new Set([
+    'track',
+  ]),
+
+  'defer': new Set([
+    'script',
+  ]),
+
+  'dir': 'GLOBAL',
+
+  'dirname': new Set([
+    'input',
+    'textarea',
+  ]),
+
+  'disabled': new Set([
+    'button',
+    'command',
+    'fieldset',
+    'input',
+    'keygen',
+    'optgroup',
+    'option',
+    'select',
+    'textarea',
+  ]),
+
+  'download': new Set([
+    'a',
+    'area',
+  ]),
+
+  'draggable': 'GLOBAL',
+
+  'dropzone': 'GLOBAL',
+
+  'enctype': new Set([
+    'form',
+  ]),
+
+  // FIXME translate from htmlFor
+  'for': new Set([
+    'label',
+    'output',
+  ]),
+
+  'form': new Set([
+    'button',
+    'fieldset',
+    'input',
+    'keygen',
+    'label',
+    'meter',
+    'object',
+    'output',
+    'progress',
+    'select',
+    'textarea',
+  ]),
+
+  'formaction': new Set([
+    'input',
+    'button',
+  ]),
+
+  'headers': new Set([
+    'td',
+    'th',
+  ]),
+
+  'height': new Set([
+    'canvas',
+    'embed',
+    'iframe',
+    'img',
+    'input',
+    'object',
+    'video',
+  ]),
+
+  'hidden': 'GLOBAL',
+
+  'high': new Set([
+    'meter',
+  ]),
 
   'href': new Set([
     'a',
@@ -64,7 +268,6 @@ function isStandardAttribute(attrName, tagName) {
   var attr = HTML_ATTRIBUTES[attrName.toLowerCase()];
   return !!attr && (
     attr === 'GLOBAL' ||
-    attr === tagName ||
     attr.has(tagName)
   );
 }

--- a/attributes-elements.js
+++ b/attributes-elements.js
@@ -1,0 +1,75 @@
+/**
+ * A map of HTML element types to the HTML attributes they can have.
+ * See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
+ * @module attributes-elements
+ */
+
+var HTML_ATTRIBUTES = {
+  'accept': new Set([
+    'form',
+    'input',
+  ]),
+
+  'accept-charset': 'form',
+
+  'accesskey': 'GLOBAL',
+
+  'action': 'form',
+
+  'align': new Set([
+    'applet',
+    'caption',
+    'col',
+    'colgroup',
+    'hr',
+    'iframe',
+    'img',
+    'table',
+    'tbody',
+    'td',
+    'tfoot',
+    'th',
+    'thead',
+    'tr',
+  ]),
+
+  'alt': new Set([
+    'applet',
+    'area',
+    'img',
+    'input',
+  ]),
+
+  'async': 'script',
+
+  'autocomplete': new Set([
+    'form',
+    'input',
+  ]),
+
+  // TODO
+
+  'href': new Set([
+    'a',
+    'area',
+    'base',
+    'link',
+  ]),
+
+  // TODO
+};
+
+function isStandardAttribute(attrName, tagName) {
+  tagName = tagName.toLowerCase();
+  var attr = HTML_ATTRIBUTES[attrName.toLowerCase()];
+  return !!attr && (
+    attr === 'GLOBAL' ||
+    attr === tagName ||
+    attr.has(tagName)
+  );
+}
+
+module.exports = {
+  isStandardAttribute: isStandardAttribute,
+  HTML_ATTRIBUTES: HTML_ATTRIBUTES,
+};

--- a/attributes-elements.js
+++ b/attributes-elements.js
@@ -260,7 +260,320 @@ var HTML_ATTRIBUTES = {
     'link',
   ]),
 
-  // TODO
+  'hreflang': new Set([
+    'a',
+    'area',
+    'link',
+  ]),
+
+  'http-equiv': new Set([
+    'meta',
+  ]),
+
+  'icon': new Set([
+    'command',
+  ]),
+
+  'id': 'GLOBAL',
+
+  'ismap': new Set([
+    'img',
+  ]),
+
+  'itemprop': 'GLOBAL',
+
+  'keytype': new Set([
+    'keygen',
+  ]),
+
+  'kind': new Set([
+    'track',
+  ]),
+
+  'label': new Set([
+    'track',
+  ]),
+
+  'lang': 'GLOBAL',
+
+  'language': new Set([
+    'script',
+  ]),
+
+  'list': new Set([
+    'input',
+  ]),
+
+  'loop': new Set([
+    'audio',
+    'bgsound',
+    'marquee',
+    'video',
+  ]),
+
+  'low': new Set([
+    'meter',
+  ]),
+
+  'manifest': new Set([
+    'html',
+  ]),
+
+  'max': new Set([
+    'input',
+    'meter',
+    'progress',
+  ]),
+
+  'maxlength': new Set([
+    'input',
+    'textarea',
+  ]),
+
+  'media': new Set([
+    'a',
+    'area',
+    'link',
+    'source',
+    'style',
+  ]),
+
+  'method': new Set([
+    'form',
+  ]),
+
+  'min': new Set([
+    'input',
+    'meter',
+  ]),
+
+  'multiple': new Set([
+    'input',
+    'select',
+  ]),
+
+  'muted': new Set([
+    'video',
+  ]),
+
+  'name': new Set([
+    'button',
+    'form',
+    'fieldset',
+    'iframe',
+    'input',
+    'keygen',
+    'object',
+    'output',
+    'select',
+    'textarea',
+    'map',
+    'meta',
+    'param',
+  ]),
+
+  'novalidate': new Set([
+    'form',
+  ]),
+
+  'open': new Set([
+    'details',
+  ]),
+
+  'optimum': new Set([
+    'meter',
+  ]),
+
+  'pattern': new Set([
+    'input',
+  ]),
+
+  'ping': new Set([
+    'a',
+    'area',
+  ]),
+
+  'placeholder': new Set([
+    'input',
+    'textarea',
+  ]),
+
+  'poster': new Set([
+    'video',
+  ]),
+
+  'preload': new Set([
+    'audio',
+    'video',
+  ]),
+
+  'radiogroup': new Set([
+    'command',
+  ]),
+
+  'readonly': new Set([
+    'input',
+    'textarea',
+  ]),
+
+  'rel': new Set([
+    'a',
+    'area',
+    'link',
+  ]),
+
+  'required': new Set([
+    'input',
+    'select',
+    'textarea',
+  ]),
+
+  'reversed': new Set([
+    'ol',
+  ]),
+
+  'rows': new Set([
+    'textarea',
+  ]),
+
+  'rowspan': new Set([
+    'td',
+    'th',
+  ]),
+
+  'sandbox': new Set([
+    'iframe',
+  ]),
+
+  'scope': new Set([
+    'th',
+  ]),
+
+  'scoped': new Set([
+    'style',
+  ]),
+
+  'seamless': new Set([
+    'iframe',
+  ]),
+
+  'selected': new Set([
+    'option',
+  ]),
+
+  'shape': new Set([
+    'a',
+    'area',
+  ]),
+
+  'size': new Set([
+    'input',
+    'select',
+  ]),
+
+  'sizes': new Set([
+    'img',
+    'link',
+    'source',
+  ]),
+
+  'span': new Set([
+    'col',
+    'colgroup',
+  ]),
+
+  'spellcheck': 'GLOBAL',
+
+  'src': new Set([
+    'audio',
+    'embed',
+    'iframe',
+    'img',
+    'input',
+    'script',
+    'source',
+    'track',
+    'video',
+  ]),
+
+  'srcdoc': new Set([
+    'iframe',
+  ]),
+
+  'srclang': new Set([
+    'track',
+  ]),
+
+  'srcset': new Set([
+    'img',
+  ]),
+
+  'start': new Set([
+    'ol',
+  ]),
+
+  'step': new Set([
+    'input',
+  ]),
+
+  'style': 'GLOBAL',
+
+  'summary': new Set([
+    'table',
+  ]),
+
+  'tabindex': 'GLOBAL',
+
+  'target': new Set([
+    'a',
+    'area',
+    'base',
+    'form',
+  ]),
+
+  'title': 'GLOBAL',
+
+  'type': new Set([
+    'button',
+    'input',
+    'command',
+    'embed',
+    'object',
+    'script',
+    'source',
+    'style',
+    'menu',
+  ]),
+
+  'usemap': new Set([
+    'img',
+    'input',
+    'object',
+  ]),
+
+  'value': new Set([
+    'button',
+    'option',
+    'input',
+    'li',
+    'meter',
+    'progress',
+    'param',
+  ]),
+
+  'width': new Set([
+    'canvas',
+    'embed',
+    'iframe',
+    'img',
+    'input',
+    'object',
+    'video',
+  ]),
+
+  'wrap': new Set([
+    'textarea',
+  ]),
 };
 
 function isStandardAttribute(attrName, tagName) {

--- a/html-attributes.js
+++ b/html-attributes.js
@@ -1,9 +1,16 @@
 /**
- * A map of HTML element types to the HTML attributes they can have.
- * See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
- * @module attributes-elements
+ * Utils for HTML attributes
+ * @module html-attributes
  */
 
+// property to attribute names
+var PROPS_TO_ATTRS = {
+  'className': 'class',
+  'htmlFor': 'for',
+};
+
+// map of attributes to the elements they affect
+// see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
 var HTML_ATTRIBUTES = {
   'accept': new Set([
     'form',
@@ -207,7 +214,6 @@ var HTML_ATTRIBUTES = {
     'form',
   ]),
 
-  // FIXME translate from htmlFor
   'for': new Set([
     'label',
     'output',
@@ -585,7 +591,11 @@ function isStandardAttribute(attrName, tagName) {
   );
 }
 
+function propToAttr(prop) {
+  return PROPS_TO_ATTRS[prop] || prop;
+}
+
 module.exports = {
   isStandardAttribute: isStandardAttribute,
-  HTML_ATTRIBUTES: HTML_ATTRIBUTES,
+  propToAttr: propToAttr,
 };

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ global.Text     = Text
 global.document = new Document()
 
 var ClassList = require('class-list')
+var isStandardAttribute = require('./attributes-elements').isStandardAttribute;
 
 function Document() {}
 
@@ -256,7 +257,7 @@ Element.prototype.__defineGetter__('outerHTML', function () {
     return attr.length ? ' '+attr.join(" ") : '';
   }
 
-   function _propertify() {
+  function _propertify() {
     var props = [];
     for (var key in self) {
       _isProperty(key) && props.push({name: key, value:self[key]});
@@ -268,15 +269,9 @@ Element.prototype.__defineGetter__('outerHTML', function () {
   }
 
   function _isProperty(key) {
-      var types = ['string','boolean','number']
-      for (var i=0; i<=types.length;i++) {
-        if (self.hasOwnProperty(key) &&
-            types[i] === typeof self[key] &&
-            key !== 'nodeName' &&
-            key !== 'nodeType' &&
-            key !== 'className'
-            ) return true;
-      }
+    return self.hasOwnProperty(key) &&
+      ['string', 'boolean', 'number'].indexOf(typeof self[key]) !== -1 &&
+      isStandardAttribute(key, self.nodeName);
   }
 
   var attrs = this.style.cssText ? this.attributes.concat([{name: 'style'}]) : this.attributes;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ global.Text     = Text
 global.document = new Document()
 
 var ClassList = require('class-list')
-var isStandardAttribute = require('./attributes-elements').isStandardAttribute;
+var htmlAttributes = require('./html-attributes');
 
 function Document() {}
 
@@ -260,18 +260,29 @@ Element.prototype.__defineGetter__('outerHTML', function () {
   function _propertify() {
     var props = [];
     for (var key in self) {
-      _isProperty(key) && props.push({name: key, value:self[key]});
+      var attrName = htmlAttributes.propToAttr(key);
+      if (
+        self.hasOwnProperty(key) &&
+        ['string', 'boolean', 'number'].indexOf(typeof self[key]) !== -1 &&
+        htmlAttributes.isStandardAttribute(attrName, self.nodeName) &&
+        _shouldOutputProp(key, attrName)
+      ) {
+        props.push({name: attrName, value: self[key]});
+      }
     }
-    // special className case, if className property is define while 'class' attribute is not then
-    // include class attribute in output
-    self.className.length && !self.getAttribute('class') && props.push({name:'class', value: self.className})
     return props ? _stringify(props) : '';
   }
 
-  function _isProperty(key) {
-    return self.hasOwnProperty(key) &&
-      ['string', 'boolean', 'number'].indexOf(typeof self[key]) !== -1 &&
-      isStandardAttribute(key, self.nodeName);
+  function _shouldOutputProp(prop, attr) {
+    if (self.getAttribute(attr)) {
+      // let explicitly-set attributes override props
+      return false;
+    } else {
+      if (prop === 'className' && !self[prop]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   var attrs = this.style.cssText ? this.attributes.concat([{name: 'style'}]) : this.attributes;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/1N50MN14/html-element.git"
   },
   "devDependencies": {
-    "tap": "~0.4.0"
+    "tap": "^6.3.0"
   },
   "author": "ins0mnia <ayman.mackouly@gmail.com> (http://github.com/1N50MN14)",
   "license": "MIT",

--- a/test/index.js
+++ b/test/index.js
@@ -177,6 +177,14 @@ test('render outerHTML with inline style', function(t){
   t.end()
 })
 
+test('outerHTML should include only HTML attributes', function(t) {
+  var a = document.createElement('a')
+  a.href = '/link'
+  a.foo = 'bar'
+  t.equal(a.outerHTML, '<a href="/link"></a>')
+  t.end()
+})
+
 test('removeAttribute', function(t){
   var div = document.createElement('div')
   div.setAttribute('data-id', 100)

--- a/test/index.js
+++ b/test/index.js
@@ -182,6 +182,12 @@ test('outerHTML should include only HTML attributes', function(t) {
   a.href = '/link'
   a.foo = 'bar'
   t.equal(a.outerHTML, '<a href="/link"></a>')
+
+  var div = document.createElement('div')
+  div.href = '/invalid'
+  div.tabindex = 2
+  t.equal(div.outerHTML, '<div tabindex="2"></div>')
+
   t.end()
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -191,6 +191,19 @@ test('outerHTML should include only HTML attributes', function(t) {
   t.end()
 })
 
+test('outerHTML should translate props to attrs', function(t) {
+  var label = document.createElement('label')
+  label.headers = 'invalid'
+  label.htmlFor = 'respect'
+  t.equal(label.outerHTML, '<label for="respect"></label>')
+
+  var div = document.createElement('div')
+  div.className = 'foo bar'
+  t.equal(div.outerHTML, '<div class="foo bar"></div>')
+
+  t.end()
+})
+
 test('removeAttribute', function(t){
   var div = document.createElement('div')
   div.setAttribute('data-id', 100)


### PR DESCRIPTION
i.e. [IDL Attributes vs Content Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#Content_versus_IDL_attributes)

- handles a few common cases of HTML props which are reflected in different attribute names (`htmlFor` -> `for`, `className` -> `class`)
- prohibits the HTML output of arbitrary props (so running `myDiv.foo = 'bar'` should _not_ result in outerHTML of `<div foo="bar">`; you need to use `myDiv.setAttribute('foo', 'bar')` to do that)
- defaults to 1-to-1 mapping of prop-to-attr names for all the standard HTML attributes from https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes, which is certainly not as nuanced as the real situation around translating IDL Attributes to Content Attributes, but should enable all the standard cases (such as the `href` prop of an anchor element being reflected in the `href` attribute of the `<a>` tag)
- upgrades `tap` to the current version, for better output and debugging

NB the implementation of mapping attribute names to allowed tag names is done with ES2015's `Set` structure, which means you need node >= 0.12, but I figure that's a pretty safe bet nowadays. If you find that objectionable, I can rework it with arrays instead.