### PR TITLE
some implementation fixes around node-insertion and textContent

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,13 +169,19 @@ Element.prototype.removeChild = function(rChild) {
 
 Element.prototype.insertBefore = function (newChild, existingChild) {
   var childNodes = this.childNodes;
-  for (var i = 0, len = childNodes.length; i < len; i++) {
-    var child = childNodes[i];
-    if (child === existingChild) {
-      i === 0 ? childNodes.unshift(newChild) : childNodes.splice(i, 0, newChild);
-      break;
+
+  if (existingChild === null) {
+    childNodes.push(newChild);
+  } else {
+    for (var i = 0, len = childNodes.length; i < len; i++) {
+      var child = childNodes[i];
+      if (child === existingChild) {
+        i === 0 ? childNodes.unshift(newChild) : childNodes.splice(i, 0, newChild);
+        break;
+      }
     }
   }
+
   return newChild;
 }
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ Document.prototype.createTextNode = function(v) {
 
 Document.prototype.createElement = function(nodeName) {
     var el = new Element();
-    el.nodeName = nodeName;
+    el.nodeName = el.tagName = nodeName;
     return el;
 }
 

--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ Element.prototype.replaceChild = function(newChild, oldChild) {
     this.childNodes.forEach(function(child, index){
         if (child === oldChild) {
             self.childNodes[index] = newChild;
+            newChild.parentElement = this;
             replaced = true;
         }
     });
@@ -160,7 +161,8 @@ Element.prototype.removeChild = function(rChild) {
     this.childNodes.forEach(function(child, index){
         if (child === rChild) {
           // use splice to keep a clean childNode array
-          self.childNodes.splice(index, 1)
+          self.childNodes.splice(index, 1);
+          rChild.parentElement = null;
           removed = true;
         }
     })
@@ -181,6 +183,7 @@ Element.prototype.insertBefore = function (newChild, existingChild) {
       }
     }
   }
+  newChild.parentElement = this;
 
   return newChild;
 }

--- a/index.js
+++ b/index.js
@@ -304,6 +304,13 @@ Element.prototype.__defineGetter__('textContent', function () {
   return s
 })
 
+Element.prototype.__defineSetter__('textContent', function (v) {
+  var textNode = new Text()
+  textNode.textContent = v
+  this.childNodes = [textNode]
+  return v
+})
+
 Element.prototype.addEventListener = function(t, l) {}
 
 function escapeHTML(s) {

--- a/test/index.js
+++ b/test/index.js
@@ -20,11 +20,25 @@ test('assign textContent to an Element', function(t){
   var div = document.createElement('div')
   t.equal(clean(div.textContent), '')
 
+  // adds and replaces text
   div.textContent = 'text 1'
   t.equal(clean(div.textContent), 'text 1')
-
   div.textContent = 'text 2'
   t.equal(clean(div.textContent), 'text 2')
+
+  // replaces existing children
+  div = document.createElement('div')
+  var p1 = document.createElement('p')
+  var p2 = document.createElement('p')
+  div.appendChild(p1)
+  div.appendChild(p2)
+  t.same(div.childNodes[0], p1)
+  t.same(div.childNodes[1], p2)
+  t.equal(clean(div.textContent), '')
+  div.textContent = 'replacement'
+  t.equal(clean(div.textContent), 'replacement')
+  t.equal(div.childNodes.length, 1)
+  t.notSame(div.childNodes[0], p1)
 
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -274,11 +274,13 @@ test('insertBefore', function(t){
   var children = div.childNodes
   t.same(children[0], div1)
   t.same(children[1], div2)
+  t.same(div2.parentNode, div)
 
   var div3 = document.createElement('div')
   div.insertBefore(div3, div2)
   t.same(children[1], div3)
   t.same(children[2], div2)
+  t.same(div2.parentNode, div)
 
   // If referenceNode is null, the newNode is inserted
   // at the end of the list of child nodes.
@@ -286,6 +288,13 @@ test('insertBefore', function(t){
   div.insertBefore(div4, null)
   t.same(children[2], div2)
   t.same(children[3], div4)
+  t.same(div4.parentNode, div)
+
+  // insertBefore should set parentNode
+  var div5 = document.createElement('div')
+  div.insertBefore(div5, div4)
+  t.same(children[3], div5)
+  t.same(div5.parentNode, div)
 
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -247,9 +247,18 @@ test('insertBefore', function(t){
   var children = div.childNodes
   t.same(children[0], div1)
   t.same(children[1], div2)
+
   var div3 = document.createElement('div')
   div.insertBefore(div3, div2)
   t.same(children[1], div3)
   t.same(children[2], div2)
+
+  // If referenceNode is null, the newNode is inserted
+  // at the end of the list of child nodes.
+  var div4 = document.createElement('div')
+  div.insertBefore(div4, null)
+  t.same(children[2], div2)
+  t.same(children[3], div4)
+
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,20 @@ test('Element attributes', function(t){
   t.equal(div.nodeName, 'div')
   t.equal(div.tagName, 'div')
 
-  t.end();
+  t.end()
+})
+
+test('assign textContent to an Element', function(t){
+  var div = document.createElement('div')
+  t.equal(clean(div.textContent), '')
+
+  div.textContent = 'text 1'
+  t.equal(clean(div.textContent), 'text 1')
+
+  div.textContent = 'text 2'
+  t.equal(clean(div.textContent), 'text 2')
+
+  t.end()
 })
 
 test('create a Text node', function(t){

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,14 @@ function clean(e) {
           .replace(/\s+/, ' ')
 }
 
+test('Element attributes', function(t){
+  var div = document.createElement('div')
+  t.equal(div.nodeName, 'div')
+  t.equal(div.tagName, 'div')
+
+  t.end();
+})
+
 test('create a Text node', function(t){
   var h1 = document.createElement('h1')
   t.equal(clean(h1.outerHTML), "<h1></h1>")


### PR DESCRIPTION
- `Element` should respond to [`tagName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName)
- `Node.insertBefore()` with a `null` second argument should append (["If `referenceNode` is null, the `newNode` is inserted at the end of the list of child nodes"](https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore))
- `textContent` can be set on Element nodes (["Setting this property on a node removes all of its children and replaces them with a single text node with the given value"](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent))
- `parentElement`/`parentNode` should be set by `insertBefore`, not just `appendChild`