### PR TITLE
Add missing minlength attribute

### DIFF
--- a/html-attributes.js
+++ b/html-attributes.js
@@ -336,6 +336,11 @@ var HTML_ATTRIBUTES = {
     'textarea',
   ]),
 
+  'maxlength': new Set([
+    'input',
+    'textarea',
+  ]),
+
   'media': new Set([
     'a',
     'area',

--- a/test/index.js
+++ b/test/index.js
@@ -404,3 +404,11 @@ test('dispatchEvent', function(t) {
 
   t.end();
 });
+
+test('Input with minlength and maxlength', function(t){
+  var input = document.createElement('input')
+  input.setAttribute('minlength', 42)
+  input.setAttribute('maxlength', 420)
+  t.equal(input.outerHTML, '<input minlength="42" maxlength="420">')
+  t.end()
+})


### PR DESCRIPTION
Problem: The `minlength` attribute was missing from `html-attributes.js`
which meant that it was never included in the `outerHTML`.

Solution: Add the attribute and a test to ensure that this works and
that we can prevent future regressions.

Resolves https://github.com/1N50MN14/html-element/issues/41