### PR TITLE
Rename duplicated maxlength attribute to minlength

### DIFF
--- a/html-attributes.js
+++ b/html-attributes.js
@@ -336,7 +336,7 @@ var HTML_ATTRIBUTES = {
     'textarea',
   ]),
 
-  'maxlength': new Set([
+  'minlength': new Set([
     'input',
     'textarea',
   ]),


### PR DESCRIPTION
Duplicate `maxlength` attribute was added in `html-attributes.js`
instead of intended `minlength` attribute in #42

Resolves #45