### PR TITLE
Added missing item* global attributes

### DIFF
--- a/html-attributes.js
+++ b/html-attributes.js
@@ -286,7 +286,15 @@ var HTML_ATTRIBUTES = {
     'img',
   ]),
 
+  'itemid': 'GLOBAL',
+
   'itemprop': 'GLOBAL',
+
+  'itemref': 'GLOBAL',
+
+  'itemscope': 'GLOBAL',
+  
+  'itemtype': 'GLOBAL',
 
   'keytype': new Set([
     'keygen',


### PR DESCRIPTION
While `itemprop` is included, all the other associated global `item*` attributes are missing.

See the `itemprop` examples here for more info: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/itemprop

Thanks!